### PR TITLE
Msip cloud env type admx

### DIFF
--- a/ADMX/MSIP/CloudEnvType.xml
+++ b/ADMX/MSIP/CloudEnvType.xml
@@ -1,0 +1,3 @@
+<enabled/>
+
+<data id="CloudEnvType" value="2"/>

--- a/ADMX/MSIP/MIP_Cloud.admx
+++ b/ADMX/MSIP/MIP_Cloud.admx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+ <policyNamespaces>
+    <target prefix="MSIP" namespace="Cooey.MSIP>" />
+    <using prefix="Cooey" namespace="Cooey.Policies.Common" />
+	<using prefix="windows" namespace="Microsoft.Policies.Windows" />
+ </policyNamespaces>
+ <resources minRequiredRevision="1.0" />
+  <categories>
+    <category name="CloudEnvironment" displayName="$(string.CloudEnvironmentDisplay)">
+	<parentCategory ref="Cooey" />
+	</category>
+  </categories>
+  <policies>
+
+   <policy name="WebServiceUrl" class="Machine" displayName="$(string.WebServiceUrl)" explainText="$(string.WebServiceUrl_Help)" presentation="$(presentation.WebServiceUrl)" key="SOFTWARE\WOW6432Node\Microsoft\MSIP">
+    <parentCategory ref="CloudEnvironment" />
+     <supportedOn ref="windows:SUPPORTED_WindowsVista" />
+     <elements>
+        <text id="WebServiceUrl" valueName="WebServiceUrl" required="true" />
+     </elements>
+   </policy>
+
+   <policy name="CloudEnvType" class="Machine" displayName="$(string.CloudEnvType)" explainText="$(string.CloudEnvType_Help)" presentation="$(presentation.CloudEnvType)" key="SOFTWARE\WOW6432Node\Microsoft\MSIP">
+      <parentCategory ref="CloudEnvironment" />
+      <supportedOn ref="windows:SUPPORTED_WindowsVista" />
+      <elements>
+        <enum id="CloudEnvType" valueName="CloudEnvType">
+          <item displayName="$(string.Commercial)">
+            <value>
+              <decimal value="0" />
+            </value>
+          </item>
+          <item displayName="$(string.GCC)">
+            <value>
+              <decimal value="1" />
+            </value>
+          </item>
+          <item displayName="$(string.GCC_High)">
+            <value>
+              <decimal value="2" />
+            </value>
+          </item>
+          <item displayName="$(string.DoD)">
+            <value>
+              <decimal value="3" />
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	
+  </policies>
+</policyDefinitions>

--- a/ADMX/MSIP/Readme.md
+++ b/ADMX/MSIP/Readme.md
@@ -1,0 +1,24 @@
+# Purpose
+Sets the value for the MSIP/AIP client using Intune, with full compliance visibility
+
+# Usage 
+Both of these files must be uploaded to Microsoft Intune using a Custom policy, which will allow you to directly reference an OMA-URI.
+
+You can use the same Custom policy to deploy both settings. Name it what you wish.
+
+1. Create a new Custom Policy in Intune.
+2. Create a new OMA-URI Setting. I named min MSIP.admx
+3. for the OMA-URI, type: ./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXInstall/MSIP/Policy/MSIP.Admx
+4. For the Value, paste in the contents of the MSIP.admx file as a String. Set the description if desired.
+5. Add a second new OMA-URI Setting called "CloudEnvType"
+6. For the OMA-URI, type: ./Device/Vendor/MSFT/Policy/Config/MSIP~Policy~CloudEnvironment/CloudEnvType
+7. For the Value, paste in the Contents of the .xml file, and substitue another value for the '2' if you aren't in GCCH.
+8. Save all settings and deploy to your test group, then to prod.
+
+# Author
+@garrett-wood
+
+# References
+https://somedownti.me/2020/06/02/import-administrative-templates-admx-into-intune/  
+https://docs.microsoft.com/en-us/enterprise-mobility-security/solutions/ems-aip-premium-govt-service-description  
+https://4sysops.com/archives/how-to-create-an-admx-template/#admx-template-structure

--- a/ADMX/MSIP/Readme.md
+++ b/ADMX/MSIP/Readme.md
@@ -2,17 +2,15 @@
 Sets the value for the MSIP/AIP client using Intune, with full compliance visibility
 
 # Usage 
-Both of these files must be uploaded to Microsoft Intune using a Custom policy, which will allow you to directly reference an OMA-URI.
-
-You can use the same Custom policy to deploy both settings. Name it what you wish.
+Both of these files must be uploaded to Microsoft Intune using a Custom policy, which will allow you to directly reference an OMA-URI. You can use the same Custom policy to deploy both settings. Name it what you wish. Both the 'new' and 'old' registry values can be customized, but only the 'new' registry value is in this list. If you're using the old one for some reason, I'd recommend upgrading.
 
 1. Create a new Custom Policy in Intune.
-2. Create a new OMA-URI Setting. I named min MSIP.admx
-3. for the OMA-URI, type: ./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXInstall/MSIP/Policy/MSIP.Admx
+2. Create a new OMA-URI Setting. I named min `MSIP.admx`
+3. for the OMA-URI, type: `./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXInstall/MSIP/Policy/MSIP.Admx`
 4. For the Value, paste in the contents of the MSIP.admx file as a String. Set the description if desired.
-5. Add a second new OMA-URI Setting called "CloudEnvType"
-6. For the OMA-URI, type: ./Device/Vendor/MSFT/Policy/Config/MSIP~Policy~CloudEnvironment/CloudEnvType
-7. For the Value, paste in the Contents of the .xml file, and substitue another value for the '2' if you aren't in GCCH.
+5. Add a second new OMA-URI Setting called `CloudEnvType`
+6. For the OMA-URI, type: `./Device/Vendor/MSFT/Policy/Config/MSIP~Policy~CloudEnvironment/CloudEnvType`
+7. For the Value, paste in the Contents of the CloudEnvType.xml file, and substitue another value for the '2' if you aren't in GCCH.
 8. Save all settings and deploy to your test group, then to prod.
 
 # Author


### PR DESCRIPTION
Added a custom ADMX file and a way to address it to set the CloudEnvType for AIP/MIP/MSIP using Intune in a way you could actually see if it failed, and could guarantee continued application if something was changed on the endpoint.